### PR TITLE
Implement a QuickCheck printer

### DIFF
--- a/src/QuickSpec.hs
+++ b/src/QuickSpec.hs
@@ -90,13 +90,13 @@ module QuickSpec(
   -- * Customising QuickSpec
   withMaxTermSize, withMaxTests, withMaxTestSize, defaultTo,
   withPruningDepth, withPruningTermSize, withFixedSeed,
-  withInferInstanceTypes,
+  withInferInstanceTypes, withPrintStyle, PrintStyle(..),
 
   -- * Re-exported functionality
   Typeable, (:-)(..), Dict(..), Proxy(..), Arbitrary) where
 
 import QuickSpec.Internal
-import QuickSpec.Internal.Haskell(Observe(..))
+import QuickSpec.Internal.Haskell(Observe(..), PrintStyle(..))
 import QuickSpec.Internal.Type(A, B, C, D, E)
 import Data.Typeable
 import Data.Constraint

--- a/src/QuickSpec.hs
+++ b/src/QuickSpec.hs
@@ -92,7 +92,7 @@ module QuickSpec(
   withPruningDepth, withPruningTermSize, withFixedSeed,
   withInferInstanceTypes, withPrintStyle, PrintStyle(..),
 
-  -- * Integrating with QuickSpec
+  -- * Integrating with QuickCheck
   (=~=),
 
   -- * Re-exported functionality

--- a/src/QuickSpec.hs
+++ b/src/QuickSpec.hs
@@ -104,4 +104,3 @@ import QuickSpec.Internal.Type(A, B, C, D, E)
 import Data.Typeable
 import Data.Constraint
 import Test.QuickCheck
-

--- a/src/QuickSpec.hs
+++ b/src/QuickSpec.hs
@@ -99,12 +99,9 @@ module QuickSpec(
   Typeable, (:-)(..), Dict(..), Proxy(..), Arbitrary) where
 
 import QuickSpec.Internal
-import QuickSpec.Internal.Haskell(Observe(..), PrintStyle(..))
+import QuickSpec.Internal.Haskell(Observe(..), PrintStyle(..), (=~=))
 import QuickSpec.Internal.Type(A, B, C, D, E)
 import Data.Typeable
 import Data.Constraint
 import Test.QuickCheck
 
-
-(=~=) :: (Show test, Show outcome, Observe test outcome a) => a -> a -> Property
-a =~= b = property $ \test -> observe test a === observe test b

--- a/src/QuickSpec.hs
+++ b/src/QuickSpec.hs
@@ -92,6 +92,9 @@ module QuickSpec(
   withPruningDepth, withPruningTermSize, withFixedSeed,
   withInferInstanceTypes, withPrintStyle, PrintStyle(..),
 
+  -- * Integrating with QuickSpec
+  (=~=),
+
   -- * Re-exported functionality
   Typeable, (:-)(..), Dict(..), Proxy(..), Arbitrary) where
 
@@ -101,3 +104,7 @@ import QuickSpec.Internal.Type(A, B, C, D, E)
 import Data.Typeable
 import Data.Constraint
 import Test.QuickCheck
+
+
+(=~=) :: (Show test, Show outcome, Observe test outcome a) => a -> a -> Property
+a =~= b = property $ \test -> observe test a === observe test b

--- a/src/QuickSpec/Internal.hs
+++ b/src/QuickSpec/Internal.hs
@@ -272,6 +272,9 @@ withMaxTestSize n =
 defaultTo :: Typeable a => proxy a -> Sig
 defaultTo proxy = Sig (\_ -> setL Haskell.lens_default_to (typeRep proxy))
 
+withPrintStyle :: Haskell.PrintStyle -> Sig
+withPrintStyle style = Sig (\_ -> setL Haskell.lens_print_style style)
+
 -- | Set how hard QuickSpec tries to filter out redundant equations (default: no limit).
 --
 -- If you experience long pauses when running QuickSpec, try setting this number

--- a/src/QuickSpec/Internal/Haskell.hs
+++ b/src/QuickSpec/Internal/Haskell.hs
@@ -279,6 +279,17 @@ data Constant =
     con_size :: Int,
     con_classify :: Classification Constant }
 
+quickcheckEqOperator :: Constant
+quickcheckEqOperator = Constant
+  { con_name  = "==="
+  , con_style = infixStyle 9  -- high precedence to always force parens
+  , con_value = undefined
+  , con_type = undefined
+  , con_constraints = undefined
+  , con_size = 1
+  , con_classify = Function
+  }
+
 instance Eq Constant where
   x == y =
     con_name x == con_name y && typ (con_value x) == typ (con_value y)
@@ -602,7 +613,7 @@ quickSpec cfg@Config{..} = do
                 prettyProp (names instances) prop' <+> disambiguatePropType prop
             ForQuickCheck ->
               renderStyle (style {lineLength = 78}) $
-                prettyPropQC n (names instances) prop' <+> disambiguatePropType prop
+                prettyPropQC quickcheckEqOperator n (names instances) prop' <+> disambiguatePropType prop
 
     -- XXX do this during testing
     constraintsOk = memo $ \con ->

--- a/src/QuickSpec/Internal/Haskell.hs
+++ b/src/QuickSpec/Internal/Haskell.hs
@@ -169,6 +169,10 @@ class (Arbitrary test, Ord outcome) => Observe test outcome a | a -> test outcom
 instance (Arbitrary a, Observe test outcome b) => Observe (a, test) outcome (a -> b) where
   observe (x, obs) f = observe obs (f x)
 
+-- | Like 'Test.QuickCheck.===', but using the 'Observe' typeclass instead of 'Eq'.
+(=~=) :: (Show test, Show outcome, Observe test outcome a) => a -> a -> Property
+a =~= b = property $ \test -> observe test a Test.QuickCheck.=== observe test b
+
 -- An observation function along with instances.
 -- The parameters are in this order so that we can use findInstance to get at appropriate Wrappers.
 data ObserveData a outcome where

--- a/src/QuickSpec/Internal/Haskell.hs
+++ b/src/QuickSpec/Internal/Haskell.hs
@@ -290,6 +290,17 @@ quickcheckEqOperator = Constant
   , con_classify = Function
   }
 
+quickcheckObserveOperator :: Constant
+quickcheckObserveOperator = Constant
+  { con_name  = "=~="
+  , con_style = infixStyle 9  -- high precedence to always force parens
+  , con_value = undefined
+  , con_type = undefined
+  , con_constraints = undefined
+  , con_size = 1
+  , con_classify = Function
+  }
+
 instance Eq Constant where
   x == y =
     con_name x == con_name y && typ (con_value x) == typ (con_value y)
@@ -599,6 +610,7 @@ quickSpec cfg@Config{..} = do
     instances = cfg_instances `mappend` baseInstances
 
     eval = evalHaskell cfg_default_to instances
+    is_observed = isJust . findObserver instances
 
     present funs prop = do
       norm <- normaliser
@@ -613,7 +625,14 @@ quickSpec cfg@Config{..} = do
                 prettyProp (names instances) prop' <+> disambiguatePropType prop
             ForQuickCheck ->
               renderStyle (style {lineLength = 78}) $
-                prettyPropQC quickcheckEqOperator n (names instances) prop' <+> disambiguatePropType prop
+                prettyPropQC
+                  is_observed
+                  quickcheckObserveOperator
+                  quickcheckEqOperator
+                  n
+                  (names instances)
+                  prop'
+                  <+> disambiguatePropType prop
 
     -- XXX do this during testing
     constraintsOk = memo $ \con ->

--- a/src/QuickSpec/Internal/Prop.hs
+++ b/src/QuickSpec/Internal/Prop.hs
@@ -90,14 +90,16 @@ prettyProp cands = pPrint . snd . nameVars cands
 
 prettyPropQC ::
   (Typed fun, Apply (Term fun), PrettyTerm fun) =>
-  Int -> (Type -> [String]) -> Prop (Term fun) -> Doc
-prettyPropQC nth cands x =
+  fun -> Int -> (Type -> [String]) -> Prop (Term fun) -> Doc
+prettyPropQC eq nth cands x =
   hang (text first_char <+> text "counterexample" <+> (text $ show $ show $ pPrint yo) <+> text "$") 4
-   $ hang ((text "\\" <> sep (fmap (uncurry pPrintSig) (Map.assocs var_defs))) <+> text "->") 2
-   $ hsep [ parens (pPrint lhs)
-          , text "==="
-          , parens (pPrint rhs)
-          ]
+   $ hang ppr_binds 4
+   $ pPrint $ Fun (Ordinary eq) :$: lhs :$: rhs
+
+--      hsep [ parens (pPrint lhs)
+--           , text "==="
+--           , parens (pPrint rhs)
+--           ]
 
   where
     first_char =
@@ -105,7 +107,11 @@ prettyPropQC nth cands x =
         1 -> "["
         _ -> ","
     (var_defs, (ctx :=>: yo@(lhs :=: rhs))) = nameVars cands x
-    pPrintSig name ty = parens $ text name <+> text "::" <+> pPrintType ty
+    print_sig name ty = parens $ text name <+> text "::" <+> pPrintType ty
+    ppr_binds =
+      case Map.size var_defs of
+        0 -> pPrintEmpty
+        _ -> (text "\\ " <> sep (fmap (uncurry print_sig) (Map.assocs var_defs))) <+> text "->"
 
 
 data Named fun = Name String | Ordinary fun

--- a/src/QuickSpec/Internal/Prop.hs
+++ b/src/QuickSpec/Internal/Prop.hs
@@ -100,7 +100,6 @@ prettyPropQC was_observed mk_fun nth cands x
   where
     eq = mk_fun "==="
     obs_eq = mk_fun "=~="
-    and_op = mk_fun "&&"
     eq_fn = Fun $ Ordinary $ bool eq obs_eq $ was_observed $ typ lhs_for_type
 
 

--- a/src/QuickSpec/Internal/Prop.hs
+++ b/src/QuickSpec/Internal/Prop.hs
@@ -92,7 +92,7 @@ prettyPropQC ::
   (Typed fun, Apply (Term fun), PrettyTerm fun) =>
   (Type -> Bool) -> (String -> fun) -> Int -> (Type -> [String]) -> Prop (Term fun) -> Doc
 prettyPropQC was_observed mk_fun nth cands x
-  = hang (text first_char <+> text "(" <+> ((text $ show $ show $ pPrint yo))) 2
+  = hang (text first_char <+> text "(" <+> ((text $ show $ show $ pPrint law))) 2
   $ hang (hsep [text ",", text "property", text "$"]) 4
   $ hang ppr_binds 4
   $ ppr_ctx <+> (pPrint (eq_fn :$: lhs :$: rhs) <> text ")")
@@ -113,7 +113,7 @@ prettyPropQC was_observed mk_fun nth cands x
         _ -> (hsep $ punctuate (text " &&") $ fmap (parens . pPrint) ctx) <+> text "==>"
 
     (_ :=>: (lhs_for_type :=: _)) = x
-    (var_defs, yo@(ctx :=>: (lhs :=: rhs))) = nameVars cands x
+    (var_defs, law@(ctx :=>: (lhs :=: rhs))) = nameVars cands x
     print_sig name ty = parens $ text name <+> text "::" <+> pPrintType ty
     ppr_binds =
       case Map.size var_defs of


### PR DESCRIPTION
This PR adds a `withPrintStyle` signature that changes how laws are presented. Given this signature:

```haskell
main :: IO ()
main = quickSpec
  [ withPrintStyle ForQuickCheck
  , con "+" ((+) :: Int -> Int -> Int)
  ]
```

its output becomes:

```text
== Functions ==                  
(+) :: Int -> Int -> Int

== Laws ==
quickspec_laws :: [(String, Property)]
quickspec_laws =
  [ ( "x + y = y + x"            
    , property $
        \ (x :: Int) (y :: Int) -> (x + y) === (y + x))
  , ( "(x + y) + z = x + (y + z)"
    , property $
        \ (x :: Int) (y :: Int) (z :: Int) ->
            ((x + y) + z) === (x + (y + z)))
  ]
```

Laws that require use of the `Observe` typeclass have their properties emitted using the new `(=~=) :: (Show test, Show outcome, Observe test outcome a) => a -> a -> Property` operator.

Fixes #43 