### PR TITLE
Add a signature filter for linearity

### DIFF
--- a/src/QuickSpec.hs
+++ b/src/QuickSpec.hs
@@ -91,6 +91,7 @@ module QuickSpec(
   withMaxTermSize, withMaxTests, withMaxTestSize, defaultTo,
   withPruningDepth, withPruningTermSize, withFixedSeed,
   withInferInstanceTypes, withPrintStyle, PrintStyle(..),
+  withLinearity, Linearity(..),
 
   -- * Integrating with QuickCheck
   (=~=),
@@ -99,7 +100,7 @@ module QuickSpec(
   Typeable, (:-)(..), Dict(..), Proxy(..), Arbitrary) where
 
 import QuickSpec.Internal
-import QuickSpec.Internal.Haskell(Observe(..), PrintStyle(..), (=~=))
+import QuickSpec.Internal.Haskell(Observe(..), PrintStyle(..), Linearity (..), (=~=))
 import QuickSpec.Internal.Type(A, B, C, D, E)
 import Data.Typeable
 import Data.Constraint

--- a/src/QuickSpec/Internal.hs
+++ b/src/QuickSpec/Internal.hs
@@ -275,6 +275,14 @@ defaultTo proxy = Sig (\_ -> setL Haskell.lens_default_to (typeRep proxy))
 withPrintStyle :: Haskell.PrintStyle -> Sig
 withPrintStyle style = Sig (\_ -> setL Haskell.lens_print_style style)
 
+-- | Set which equations QuickSpec considers in terms of linearity use of
+-- variables (default: show all equations, regardless of linearity).
+--
+-- If you are seeing laws that seem unhelpful due to unrealistically using the
+-- same variable in many places, try setting this value to @Linear@.
+withLinearity :: Haskell.Linearity -> Sig
+withLinearity style = Sig (\_ -> setL Haskell.lens_linearity style)
+
 -- | Set how hard QuickSpec tries to filter out redundant equations (default: no limit).
 --
 -- If you experience long pauses when running QuickSpec, try setting this number

--- a/src/QuickSpec/Internal/Term.hs
+++ b/src/QuickSpec/Internal/Term.hs
@@ -250,6 +250,8 @@ compareFuns (f :@: ts) (g :@: us) =
     compareHead (Fun f) (Fun g) = compare f g
     compareHead _ _ = error "viewApp"
 
+-- | Returns the set of linearly used variables, or 'Nothing' if any variable
+-- is used nonlinearly.
 isLinear :: Term f -> Set Var -> Maybe (Set Var)
 isLinear Fun{} m = Just m
 isLinear (t1 :$: t2) m = isLinear t1 m >>= isLinear t2

--- a/src/QuickSpec/Internal/Term.hs
+++ b/src/QuickSpec/Internal/Term.hs
@@ -258,7 +258,7 @@ isLinear (t1 :$: t2) m = isLinear t1 m >>= isLinear t2
 isLinear (Var v) m =
   case Set.member v m of
     True  -> Nothing
-    False -> Just (Set.singleton v)
+    False -> Just (Set.singleton v <> m)
 
 ----------------------------------------------------------------------
 -- * Data types a la carte-ish.

--- a/src/QuickSpec/Internal/Term.hs
+++ b/src/QuickSpec/Internal/Term.hs
@@ -16,6 +16,8 @@ import Twee.Base(Pretty(..), PrettyTerm(..), TermStyle(..), EqualsBonus, prettyP
 import Twee.Pretty
 import qualified Data.Map.Strict as Map
 import Data.Map(Map)
+import Data.Set(Set)
+import qualified Data.Set as Set
 import Data.List
 import Data.Ord
 
@@ -247,6 +249,14 @@ compareFuns (f :@: ts) (g :@: us) =
     compareHead _ (Var _) = GT
     compareHead (Fun f) (Fun g) = compare f g
     compareHead _ _ = error "viewApp"
+
+isLinear :: Term f -> Set Var -> Maybe (Set Var)
+isLinear Fun{} m = Just m
+isLinear (t1 :$: t2) m = isLinear t1 m >>= isLinear t2
+isLinear (Var v) m =
+  case Set.member v m of
+    True  -> Nothing
+    False -> Just (Set.singleton v)
 
 ----------------------------------------------------------------------
 -- * Data types a la carte-ish.


### PR DESCRIPTION
This PR adds a `withLinearity` signature, which when set to `withLinearity Linear` prevents QuickSpec from emitting laws that use variables non-linearly.

Fixes #47 