### PR TITLE
Add a flag to disable closing under antisubstitution

### DIFF
--- a/examples/AutoGeneralized.hs
+++ b/examples/AutoGeneralized.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeApplications  #-}
+
+module AutoGeneralized where
+
+import QuickSpec
+import Test.QuickCheck
+
+
+data Foo a b
+  = A a
+  | B b
+  deriving (Eq, Ord, Show)
+
+instance Arbitrary (Foo () ()) where
+  arbitrary = elements
+    [ A ()
+    , B ()
+    ]
+
+
+main = quickSpec
+  [ con "A" $ A @() @()
+  , monoType $ Proxy @(Foo () ())
+  , withAutoGeneralizedTypes False
+  ]
+

--- a/src/QuickSpec.hs
+++ b/src/QuickSpec.hs
@@ -91,6 +91,7 @@ module QuickSpec(
   withMaxTermSize, withMaxTests, withMaxTestSize, defaultTo,
   withPruningDepth, withPruningTermSize, withFixedSeed,
   withInferInstanceTypes, withPrintStyle, PrintStyle(..),
+  withAutoGeneralizedTypes,
 
   -- * Integrating with QuickCheck
   (=~=),

--- a/src/QuickSpec/Internal.hs
+++ b/src/QuickSpec/Internal.hs
@@ -272,6 +272,14 @@ withMaxTestSize n =
 defaultTo :: Typeable a => proxy a -> Sig
 defaultTo proxy = Sig (\_ -> setL Haskell.lens_default_to (typeRep proxy))
 
+-- | Set whether QuickSpec will also automatically generalize types that you
+-- give it (default: yes).
+--
+-- If you experience QuickSpec warning about missing instances for types that
+-- don't exist anywhere in your signature, try setting this to 'False'.
+withAutoGeneralizedTypes :: Bool -> Sig
+withAutoGeneralizedTypes t = Sig (\_ -> setL Haskell.lens_close_anti_subst t)
+
 withPrintStyle :: Haskell.PrintStyle -> Sig
 withPrintStyle style = Sig (\_ -> setL Haskell.lens_print_style style)
 

--- a/src/QuickSpec/Internal/Explore/Conditionals.hs
+++ b/src/QuickSpec/Internal/Explore/Conditionals.hs
@@ -41,9 +41,9 @@ instance (Typed fun, Ord fun, PrettyTerm fun, Ord norm, MonadPruner (Term (WithC
       lift (add (mapFun Normal prop))
       considerConditionalising prop
 
-conditionalsUniverse :: (Typed fun, Predicate fun) => [Type] -> [fun] -> Universe
-conditionalsUniverse tys funs =
-  universe $
+conditionalsUniverse :: (Typed fun, Predicate fun) => Bool -> [Type] -> [fun] -> Universe
+conditionalsUniverse close_antisub tys funs =
+  universe close_antisub $
     tys ++
     (map typ $
       map Normal funs ++

--- a/src/QuickSpec/Internal/Haskell.hs
+++ b/src/QuickSpec/Internal/Haskell.hs
@@ -499,6 +499,7 @@ data Config =
     -- head cfg_constants contains all the background functions.
     cfg_constants :: [[Constant]],
     cfg_default_to :: Type,
+    cfg_close_anti_subst :: Bool,
     cfg_infer_instance_types :: Bool,
     cfg_background :: [Prop (Term Constant)],
     cfg_print_filter :: Prop (Term Constant) -> Bool,
@@ -512,6 +513,7 @@ lens_max_commutative_size = lens cfg_max_commutative_size (\x y -> y { cfg_max_c
 lens_instances = lens cfg_instances (\x y -> y { cfg_instances = x })
 lens_constants = lens cfg_constants (\x y -> y { cfg_constants = x })
 lens_default_to = lens cfg_default_to (\x y -> y { cfg_default_to = x })
+lens_close_anti_subst = lens cfg_close_anti_subst (\x y -> y { cfg_close_anti_subst = x })
 lens_infer_instance_types = lens cfg_infer_instance_types (\x y -> y { cfg_infer_instance_types = x })
 lens_background = lens cfg_background (\x y -> y { cfg_background = x })
 lens_print_filter = lens cfg_print_filter (\x y -> y { cfg_print_filter = x })
@@ -527,6 +529,7 @@ defaultConfig =
     cfg_instances = mempty,
     cfg_constants = [],
     cfg_default_to = typeRep (Proxy :: Proxy Int),
+    cfg_close_anti_subst = True,
     cfg_infer_instance_types = False,
     cfg_background = [],
     cfg_print_filter = \_ -> True,
@@ -606,7 +609,7 @@ quickSpec cfg@Config{..} = do
       f cfg_constants ++ concatMap selectors (f cfg_constants)
     constants = constantsOf concat
 
-    univ = conditionalsUniverse (instanceTypes instances cfg) constants
+    univ = conditionalsUniverse cfg_close_anti_subst (instanceTypes instances cfg) constants
     instances = cfg_instances `mappend` baseInstances
 
     eval = evalHaskell cfg_default_to instances


### PR DESCRIPTION
This PR introduces `withAutoGeneralizeTypes`, which when disabled prevents the QS universe from being closed under anti-substitution. I have *absolutely no idea what the implications of this are,* --- neither the code nor a quick skim of the paper explain why this closure is necessary. That being said, disabling this option gets rid of some silly warnings.

For example, under today's behavior if my signature contains `Foo () ()`, QuickSpec will yell at me:

```text
== Functions ==                  
A :: () -> Foo () ()

WARNING: The following types have no 'Arbitrary' instance declared.
You will not get any variables of the following types:
  Foo Int Int
  Foo Int ()
  Foo () Int

WARNING: The following types have no 'Ord' or 'Observe' instance declared.
You will not get any equations about the following types:
  Foo Int Int
  Foo Int ()
  Foo () Int
```

Where do these warnings come from? As a user I have no idea! QS is creating every one-hole type for `Foo`, and then immediately defaulting them each to `Int`, but as far as I can tell, this isn't useful behavior whatsoever.

Fixes #41 