### PR TITLE
Bump stack resolver

### DIFF
--- a/quickspec.cabal
+++ b/quickspec.cabal
@@ -101,9 +101,9 @@ library
     QuickSpec.Internal.Utils
 
   Build-depends:
-    QuickCheck >= 2.10,
+    QuickCheck >= 2.14.2,
     quickcheck-instances >= 0.3.16,
-    base >= 4 && < 5,
+    base >= 4.7 && < 5,
     constraints,
     containers,
     data-lens-light >= 0.1.1,

--- a/src/QuickSpec/Internal/Type.hs
+++ b/src/QuickSpec/Internal/Type.hs
@@ -35,7 +35,7 @@ import Unsafe.Coerce
 import Data.Constraint
 import Twee.Base
 import Data.Proxy
-import Data.List
+import Data.List hiding (singleton)
 import Data.Char
 import Data.Functor.Identity
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,8 @@
-resolver: lts-16.23
+resolver: lts-19.16
 
 packages:
 - .
 extra-deps:
 - spoon-0.3.1
 - twee-lib-2.4
-- primitive-0.7.1.0
+- primitive-0.7.4.0


### PR DESCRIPTION
Includes a tiny correction since `Data.List` now also exports `singleton`, and it clashes with the one defined by `Twee` - to allow compiling with GHC 9.0.2; a `QuickCheck` version bump and `primitive` version bump.